### PR TITLE
fix: fix PyPI publish workflow and bump version to 0.3.1

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,6 +1,9 @@
 name: Publish Python distribution to PyPI
 
-on: push
+on:
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wheel-it"
-version = "0.2.0"
+version = "0.3.1"
 description = "An automated options wheel trading strategy."
 authors = [
     { name = "Vahagn Madatyan" }


### PR DESCRIPTION
## Summary
- **Bump version** in `pyproject.toml` from `0.2.0` to `0.3.1` to match the intended release tag
- **Restrict workflow trigger** in `.github/workflows/pypi-publish.yml` from `on: push` (all branches) to `on: push: tags: ['v*']`, so the build and publish jobs only run when a version tag is pushed — this prevents the TestPyPI job from failing on every branch push with `400 Bad Request` (duplicate version)

## Post-merge action required
After this PR is merged, the existing `v0.3.1` tag (which points to the old commit with version 0.2.0) must be deleted and recreated on the merged commit so the tag push triggers the fixed workflow:

```bash
# Delete the old remote tag
gh api -X DELETE repos/vahagn-madatyan/wheel-it/git/refs/tags/v0.3.1

# Delete local tag, create new one on main, and push
git tag -d v0.3.1
git pull origin main
git tag v0.3.1
git push origin v0.3.1
```

## Test plan
- [ ] Verify the workflow no longer triggers on regular branch pushes
- [ ] After re-tagging, verify the workflow runs and successfully publishes to TestPyPI and PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)