### PR TITLE
fix: restrict PyPI publish to tag pushes and bump version to 0.3.1

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,6 +1,9 @@
 name: Publish Python distribution to PyPI
 
-on: push
+on:
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wheel-it"
-version = "0.2.0"
+version = "0.3.1"
 description = "An automated options wheel trading strategy."
 authors = [
     { name = "Vahagn Madatyan" }


### PR DESCRIPTION
## Summary
- **Bump version** in `pyproject.toml` from `0.2.0` to `0.3.1` to match the intended release tag
- **Restrict workflow trigger** in `.github/workflows/pypi-publish.yml` from `on: push` (all branches) to `on: push: tags: ['v*']` (tag pushes only)

## Problem
The "Publish Python distribution to PyPI" workflow was failing with `HTTPError: 400 Bad Request` because:
1. The TestPyPI publish job ran on **every push** (no tag guard), repeatedly trying to upload the already-published 0.2.0 version
2. The version in `pyproject.toml` was never bumped from `0.2.0` to `0.3.1` to match the release tag

## Post-merge action required
After this PR is merged, the existing `v0.3.1` tag needs to be deleted and recreated on the merge commit so the fixed workflow triggers correctly:
```bash
# Delete old tag (points to commit with version 0.2.0)
gh api -X DELETE repos/vahagn-madatyan/wheel-it/git/refs/tags/v0.3.1

# Create new tag on main
git fetch origin main
git tag v0.3.1 origin/main
git push origin v0.3.1
```

## Test plan
- [x] Verify `pyproject.toml` version is `0.3.1`
- [x] Verify workflow trigger is restricted to `v*` tag pushes
- [ ] After merge: delete and recreate `v0.3.1` tag, confirm workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)